### PR TITLE
Handle null limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options in the `page-gallery` block are parsed using YAML.
 |--------|------|---------|-------------|
 |`from`|`string`|-|Query for pages to include in the gallery. Uses the same query syntax as [obsidian-dataview](https://github.com/blacksmithgu/obsidian-dataview).|
 |`fields`|`Array<string>`|[]|List of fields to display in the gallery, under the image. Supports both [frontmatter and inline fields](https://blacksmithgu.github.io/obsidian-dataview/data-annotation/).|
-|`limit`|`number`|null|Limit on the number of pages that will be displayed in the gallery. Leave this blank to display all of the pages matched by the `from` query.|
+|`limit`|`number`|100|Limit on the number of pages that will be displayed in the gallery. Set this to `null` to display all of the pages matched by the `from` query.|
 |`filter`|`boolean`|true|Whether  or  not to show the filter bar.|
 |`columns`|`number`|4|Number of columns to display at full width.|
 |`gutterSize`|`string`|`16px`|Size of the gutter between images.|

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -34,7 +34,7 @@ export default class Config {
 
   from: string
   fields: string[]
-  limit: number
+  limit: number | null
   groupBy: string | null
   sortBy: string[]
   filter: boolean

--- a/src/TileWrangler.ts
+++ b/src/TileWrangler.ts
@@ -47,7 +47,7 @@ export type TileWranglerOptions = {
   cache?: TileCache
 
   from: string | null
-  limit: number
+  limit: number | null
   fields: string[]
 
   groupBy: string | null
@@ -70,7 +70,7 @@ export default class TileWrangler {
   cache: TileCache
 
   from: string | null
-  limit: number
+  limit: number | null
   fields: string[]
   groupBy: string | null
 
@@ -129,7 +129,7 @@ export default class TileWrangler {
     const sorted: PageWithFieldValues[] = Array.from(pagesWithMeta).sort(sortFn)
 
     // Truncate the list based on `limit`.
-    const filtered = sorted.slice(0, this.limit)
+    const filtered = this.limit == null ? sorted : sorted.slice(0, this.limit)
 
     // Convert remaining pages into tiles.
     const tiles = await Promise.all(filtered.map(p => this.getCachedTileInfo(p)))


### PR DESCRIPTION
This PR updates the README to note the actual default value for `limit`, and updates the code so that when set to `null`, it displays all pages found.